### PR TITLE
Use type names that follow the best practices' naming conventions

### DIFF
--- a/com.ibm.streamsx.metrics/com.ibm.streamsx.metrics/Types.spl
+++ b/com.ibm.streamsx.metrics/com.ibm.streamsx.metrics/Types.spl
@@ -6,10 +6,10 @@
 namespace com.ibm.streamsx.metrics;
 
 /**
- * The Origin_t composite wraps the contained Type enumeration
+ * The Origin composite wraps the contained Type enumeration
  * to prevent name clashes.
  */
-public composite Origin_t {
+public composite Origin {
 	type
 		/**
 		 * The origin type specifies the metric owner, which can be following:
@@ -55,13 +55,13 @@ public composite Origin_t {
  * Hint: The portIndex is set only if the origin is either OperatorInputPort
  * or OperatorOutputPort.
  */
-type Notification_t = tuple<
+type Notification = tuple<
 	rstring domainName,
 	rstring instanceName,
 	int64 jobId,
 	rstring jobName,
 	rstring operatorName,
-	Origin_t.Type origin,
+	Origin.Type origin,
 	int32 portIndex,
 	rstring metricName,
 	int64 metricValue,

--- a/com.ibm.streamsx.metrics/impl/java/src/com/ibm/streamsx/metrics/MetricsSource.java
+++ b/com.ibm.streamsx.metrics/impl/java/src/com/ibm/streamsx/metrics/MetricsSource.java
@@ -118,7 +118,7 @@ public class MetricsSource extends AbstractOperator {
 			"The MetricsSource operator emits a metric tuple to this "
 			+ "output port for each metric, for which the operator "
 			+ "identifies a changed value. You can use the "
-			+ "[type:com.ibm.streamsx.metrics::Notification_t|Notification_t] "
+			+ "[type:com.ibm.streamsx.metrics::Notification|Notification] "
 			+ "tuple type, or any subset of the attributes specified for this "
 			+ "type. After each scan cycle, the operator emits a WindowMarker "
 			+ "to this port."

--- a/samples/com.ibm.streamsx.metrics.sample.test/com.ibm.streamsx.metrics.sample.test/Main.spl
+++ b/samples/com.ibm.streamsx.metrics.sample.test/com.ibm.streamsx.metrics.sample.test/Main.spl
@@ -1,12 +1,12 @@
 namespace com.ibm.streamsx.metrics.sample.test;
 
 use com.ibm.streamsx.metrics::MetricsSource;
-use com.ibm.streamsx.metrics::Notification_t;
+use com.ibm.streamsx.metrics::Notification;
 
 /**
  * Several numbers that are created by the Beacon and stored in metrics.
  */
-type Numbers_t = tuple<
+type MetricNumbers = tuple<
 	int64 incrementingNumber,
 	int64 randomNumber
 >;
@@ -27,7 +27,7 @@ stateful boolean createMetrics() {
  * @param numbers
  * Specifies the numbers that are created by the Beacon operator.
  */
-stateful void setMetrics(Numbers_t numbers) {
+stateful void setMetrics(MetricNumbers numbers) {
 	setCustomMetricValue("inc", numbers.incrementingNumber);
 	setCustomMetricValue("rnd", numbers.randomNumber);
 }
@@ -46,7 +46,7 @@ composite Main {
 		/*
 		 * The Beacon generates incrementing and random numbers.
 		 */
-		stream<Numbers_t> Numbers as O = Beacon() {
+		stream<MetricNumbers> Numbers as O = Beacon() {
 			param period: 5.0;
 			output O:
 				incrementingNumber = (int64)IterationCount(),
@@ -87,7 +87,7 @@ composite Main {
 		 * The MetricsSource generates a tuple for each notified metric value
 		 * change.
 		 */
-		stream<Notification_t> Notifications as O = MetricsSource() {
+		stream<Notification> Notifications as O = MetricsSource() {
 			param
 				connectionURL: getSubmissionTimeValue("connectionURL");
 //				connectionURL: "service:jmx:jmxmp://" + getHostName() + ":9975";


### PR DESCRIPTION
Issue #12 requests to apply the naming conventions that Streams
recommends. The naming conventions for type names are described here:
http://www.ibm.com/support/knowledgecenter/en/SSCRJU_4.2.0/com.ibm.streams.dev.doc/doc/str_nametype.html

The Origin_t and Notification_t types are therefore, renamed to Origin
and Notification.