### PR TITLE
Provide metric type and kind in output tuple

### DIFF
--- a/com.ibm.streamsx.metrics/com.ibm.streamsx.metrics/Types.spl
+++ b/com.ibm.streamsx.metrics/com.ibm.streamsx.metrics/Types.spl
@@ -63,6 +63,8 @@ type Notification = tuple<
 	rstring operatorName,
 	Origin.Type origin,
 	int32 portIndex,
+	rstring metricType,
+	rstring metricKind,
 	rstring metricName,
 	int64 metricValue,
 	int64 lastTimeRetrieved

--- a/com.ibm.streamsx.metrics/impl/java/src/com/ibm/streamsx/metrics/internal/MetricOwningHandler.java
+++ b/com.ibm.streamsx.metrics/impl/java/src/com/ibm/streamsx/metrics/internal/MetricOwningHandler.java
@@ -88,6 +88,8 @@ abstract class MetricOwningHandler {
 	 * The exception is thrown if submitting the tuple fails.
 	 */
 	protected void submitMetric(Metric metric) throws Exception {
+		_operatorConfiguration.get_tupleContainer().setMetricType(metric.getMetricType());
+		_operatorConfiguration.get_tupleContainer().setMetricKind(metric.getMetricKind());
 		_operatorConfiguration.get_tupleContainer().setMetricName(metric.getName());
 		_operatorConfiguration.get_tupleContainer().setMetricValue(metric.getValue());
 		_operatorConfiguration.get_tupleContainer().setLastTimeRetrieved(metric.getLastTimeRetrieved());

--- a/com.ibm.streamsx.metrics/impl/java/src/com/ibm/streamsx/metrics/internal/TupleContainer.java
+++ b/com.ibm.streamsx.metrics/impl/java/src/com/ibm/streamsx/metrics/internal/TupleContainer.java
@@ -2,6 +2,7 @@ package com.ibm.streamsx.metrics.internal;
 
 import java.math.BigInteger;
 
+import com.ibm.streams.management.MetricMetadata.Kind;
 import com.ibm.streams.operator.Attribute;
 import com.ibm.streams.operator.OutputTuple;
 import com.ibm.streams.operator.StreamSchema;
@@ -46,6 +47,16 @@ public class TupleContainer {
 	 */
 	private Integer _portIndexAttributeIndex = null;
 	
+	/**
+	 * Index of the metricType attribute.
+	 */
+	private Integer _metricTypeAttributeIndex = null;
+
+	/**
+	 * Index of the metricKind attribute.
+	 */
+	private Integer _metricKindAttributeIndex = null;
+
 	/**
 	 * Index of the metricName attribute.
 	 */
@@ -115,6 +126,14 @@ public class TupleContainer {
 		if (_originAttributeIndex  == null) {
 			Attribute attribute = schema.getAttribute("origin");
 			_originAttributeIndex = Integer.valueOf(attribute != null && attribute.getType().getMetaType() == Type.MetaType.ENUM ? attribute.getIndex() : -1) ;
+		}
+		if (_metricTypeAttributeIndex  == null) {
+			Attribute attribute = schema.getAttribute("metricType");
+			_metricTypeAttributeIndex = Integer.valueOf(attribute != null && attribute.getType().getMetaType() == Type.MetaType.RSTRING ? attribute.getIndex() : -1) ;
+		}
+		if (_metricKindAttributeIndex  == null) {
+			Attribute attribute = schema.getAttribute("metricKind");
+			_metricKindAttributeIndex = Integer.valueOf(attribute != null && attribute.getType().getMetaType() == Type.MetaType.RSTRING ? attribute.getIndex() : -1) ;
 		}
 		if (_metricNameAttributeIndex  == null) {
 			Attribute attribute = schema.getAttribute("metricName");
@@ -204,6 +223,28 @@ public class TupleContainer {
 	public void setOrigin(String origin) {
 		if (_originAttributeIndex != -1) {
 			_tuple.setString(_originAttributeIndex, origin);
+		}
+	}
+
+	/**
+	 * Optionally set the metric type in the output tuple.
+	 * 
+	 * @param metricType
+	 */
+	public void setMetricType(com.ibm.streams.management.MetricMetadata.Type metricType) {
+		if (_metricTypeAttributeIndex != -1) {
+			_tuple.setString(_metricTypeAttributeIndex, metricType.toString());
+		}
+	}
+
+	/**
+	 * Optionally set the metric kind in the output tuple.
+	 * 
+	 * @param metricKind
+	 */
+	public void setMetricKind(Kind metricKind) {
+		if (_metricKindAttributeIndex != -1) {
+			_tuple.setString(_metricKindAttributeIndex, metricKind.toString());
 		}
 	}
 


### PR DESCRIPTION
If the `rstring metricType` attribute is part of the output schema, the
metric type, which can be, for example, system or custom, is stored in
this attribute.

If the `rstring metricKind` attribute is part of the output schema, the
metric type, which can be unknown, counter, gauge, or time, is stored in
this attribute. The *unknown* value is returned for metrics that are
created with the spl.utility::createCustomMetric() function. The metricKind
was requested with issue #15.