### PR TITLE
[ISSUE #28] Retrieve PE metrics only if PE filter is specified

### DIFF
--- a/com.ibm.streamsx.metrics/impl/java/src/com/ibm/streamsx/metrics/internal/JobHandler.java
+++ b/com.ibm.streamsx.metrics/impl/java/src/com/ibm/streamsx/metrics/internal/JobHandler.java
@@ -153,7 +153,18 @@ public class JobHandler implements NotificationListener {
 	}
 	
 	protected void addPE(BigInteger peId) {
-		_peHandlers.put(peId, new PeHandler(_operatorConfiguration, _domainId, _instanceId, _jobId, _jobName, peId));
+		boolean matches = _operatorConfiguration.get_filters().matchesPeId(_domainId, _instanceId, _jobName, peId);
+		if (_trace.isInfoEnabled()) {
+			if (matches) {
+				_trace.info("The following PE meets the filter criteria and is therefore, monitored: domain=" + _domainId + ", instance=" + _instanceId + ", job=[" + _jobId + "][" + _jobName + "], peId=" + peId);
+			}
+			else { 
+				_trace.info("The following PE does not meet the filter criteria and is therefore, not monitored: domain=" + _domainId + ", instance=" + _instanceId + ", job=[" + _jobId + "][" + _jobName + "], peId=" + peId);
+			}
+		}
+		if (matches) {
+			_peHandlers.put(peId, new PeHandler(_operatorConfiguration, _domainId, _instanceId, _jobId, _jobName, peId));
+		}
 	}
 	
 	/**

--- a/com.ibm.streamsx.metrics/impl/java/src/com/ibm/streamsx/metrics/internal/PeHandler.java
+++ b/com.ibm.streamsx.metrics/impl/java/src/com/ibm/streamsx/metrics/internal/PeHandler.java
@@ -116,7 +116,7 @@ public class PeHandler extends MetricOwningHandler implements NotificationListen
 
 	@Override
 	protected boolean isRelevantMetric(String metricName) {
-		boolean isRelevant = _operatorConfiguration.get_filters().matchesPeMetricName(_domainId, _instanceId, _jobName, metricName);
+		boolean isRelevant = _operatorConfiguration.get_filters().matchesPeMetricName(_domainId, _instanceId, _jobName, _peId, metricName);
 		if (_trace.isInfoEnabled()) {
 			if (isRelevant) {
 				_trace.info("The following pe metric meets the filter criteria and is therefore, monitored: domain=" + _domainId + ", instance=" + _instanceId + ", job=[" + _jobId + "][" + _jobName + "], peId=" + _peId + ", metric=" + metricName);
@@ -135,7 +135,7 @@ public class PeHandler extends MetricOwningHandler implements NotificationListen
 	}
 
 	protected void addValidInputPort(Integer portIndex) {
-		boolean matches = _operatorConfiguration.get_filters().matchesPeInputPortIndex(_domainId, _instanceId, _jobName, portIndex);
+		boolean matches = _operatorConfiguration.get_filters().matchesPeInputPortIndex(_domainId, _instanceId, _jobName, _peId, portIndex);
 		if (_trace.isInfoEnabled()) {
 			if (matches) {
 				_trace.info("The following input port meets the filter criteria and is therefore, monitored: domain=" + _domainId + ", instance=" + _instanceId + ", job=[" + _jobId + "][" + _jobName + "], peId=" + _peId + ", port=" + portIndex);
@@ -150,7 +150,7 @@ public class PeHandler extends MetricOwningHandler implements NotificationListen
 	}
 
 	protected void addValidOutputPort(Integer portIndex) {
-		boolean matches = _operatorConfiguration.get_filters().matchesPeOutputPortIndex(_domainId, _instanceId, _jobName, portIndex);
+		boolean matches = _operatorConfiguration.get_filters().matchesPeOutputPortIndex(_domainId, _instanceId, _jobName, _peId, portIndex);
 		if (_trace.isInfoEnabled()) {
 			if (matches) {
 				_trace.info("The following output port meets the filter criteria and is therefore, monitored: domain=" + _domainId + ", instance=" + _instanceId + ", job=[" + _jobId + "][" + _jobName + "], peId=" + _peId + ", port=" + portIndex);
@@ -171,7 +171,6 @@ public class PeHandler extends MetricOwningHandler implements NotificationListen
 	 * Throws Exception if submitting the tuple failed. 
 	 */
 	public void captureMetrics() throws Exception {
-
 		// Determine the trace level status once per function.
 		boolean isDebugEnabled = _trace.isDebugEnabled();
 

--- a/com.ibm.streamsx.metrics/impl/java/src/com/ibm/streamsx/metrics/internal/PeInputPortHandler.java
+++ b/com.ibm.streamsx.metrics/impl/java/src/com/ibm/streamsx/metrics/internal/PeInputPortHandler.java
@@ -78,7 +78,7 @@ public class PeInputPortHandler extends MetricOwningHandler {
 
 	@Override
 	protected boolean isRelevantMetric(String metricName) {
-		boolean isRelevant = _operatorConfiguration.get_filters().matchesPeInputPortMetricName(_domainId, _instanceId, _jobName, _portIndex, metricName);
+		boolean isRelevant = _operatorConfiguration.get_filters().matchesPeInputPortMetricName(_domainId, _instanceId, _jobName, _peId, _portIndex, metricName);
 		if (_trace.isInfoEnabled()) {
 			if (isRelevant) {
 				_trace.info("The following input port metric meets the filter criteria and is therefore, monitored: domain=" + _domainId + ", instance=" + _instanceId + ", job=[" + _jobId + "][" + _jobName + "], peId=" + _peId + ", port=" + _portIndex + ", metric=" + metricName);

--- a/com.ibm.streamsx.metrics/impl/java/src/com/ibm/streamsx/metrics/internal/PeOutputPortHandler.java
+++ b/com.ibm.streamsx.metrics/impl/java/src/com/ibm/streamsx/metrics/internal/PeOutputPortHandler.java
@@ -78,7 +78,7 @@ public class PeOutputPortHandler extends MetricOwningHandler {
 
 	@Override
 	protected boolean isRelevantMetric(String metricName) {
-		boolean isRelevant = _operatorConfiguration.get_filters().matchesPeOutputPortMetricName(_domainId, _instanceId, _jobName, _portIndex, metricName);
+		boolean isRelevant = _operatorConfiguration.get_filters().matchesPeOutputPortMetricName(_domainId, _instanceId, _jobName, _peId, _portIndex, metricName);
 		if (_trace.isInfoEnabled()) {
 			if (isRelevant) {
 				_trace.info("The following output port metric meets the filter criteria and is therefore, monitored: domain=" + _domainId + ", instance=" + _instanceId + ", job=[" + _jobId + "][" + _jobName + "], peId=" + _peId + ", port=" + _portIndex + ", metric=" + metricName);

--- a/com.ibm.streamsx.metrics/impl/java/src/com/ibm/streamsx/metrics/internal/filter/DomainFilter.java
+++ b/com.ibm.streamsx.metrics/impl/java/src/com/ibm/streamsx/metrics/internal/filter/DomainFilter.java
@@ -7,6 +7,7 @@
 
 package com.ibm.streamsx.metrics.internal.filter;
 
+import java.math.BigInteger;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -142,11 +143,11 @@ final class DomainFilter extends PatternMatcher {
 		return matches;
 	}
 
-	public boolean matchesPeMetricName(String domainId, String instanceId, String jobName, String metricName) {
+	public boolean matchesPeId(String domainId, String instanceId, String jobName, BigInteger peId) {
 		boolean matches = matchesDomainId(domainId) && (_instanceFilters.size() > 0);
 		if (matches) {
 			for(InstanceFilter filter : _instanceFilters.values()) {
-				matches = filter.matchesPeMetricName(instanceId, jobName, metricName);
+				matches = filter.matchesPeId(instanceId, jobName, peId);
 				if (matches) {
 					break;
 				}
@@ -155,11 +156,11 @@ final class DomainFilter extends PatternMatcher {
 		return matches;
 	}
 
-	public boolean matchesPeInputPortIndex(String domainId, String instanceId, String jobName, Integer portIndex) {
+	public boolean matchesPeMetricName(String domainId, String instanceId, String jobName, BigInteger peId, String metricName) {
 		boolean matches = matchesDomainId(domainId) && (_instanceFilters.size() > 0);
 		if (matches) {
 			for(InstanceFilter filter : _instanceFilters.values()) {
-				matches = filter.matchesPeInputPortIndex(instanceId, jobName, portIndex);
+				matches = filter.matchesPeMetricName(instanceId, jobName, peId, metricName);
 				if (matches) {
 					break;
 				}
@@ -168,11 +169,11 @@ final class DomainFilter extends PatternMatcher {
 		return matches;
 	}
 
-	public boolean matchesPeInputPortMetricName(String domainId, String instanceId, String jobName, Integer portIndex, String metricName) {
+	public boolean matchesPeInputPortIndex(String domainId, String instanceId, String jobName, BigInteger peId, Integer portIndex) {
 		boolean matches = matchesDomainId(domainId) && (_instanceFilters.size() > 0);
 		if (matches) {
 			for(InstanceFilter filter : _instanceFilters.values()) {
-				matches = filter.matchesPeInputPortMetricName(instanceId, jobName, portIndex, metricName);
+				matches = filter.matchesPeInputPortIndex(instanceId, jobName, peId, portIndex);
 				if (matches) {
 					break;
 				}
@@ -181,11 +182,11 @@ final class DomainFilter extends PatternMatcher {
 		return matches;
 	}
 
-	public boolean matchesPeOutputPortIndex(String domainId, String instanceId, String jobName, Integer portIndex) {
+	public boolean matchesPeInputPortMetricName(String domainId, String instanceId, String jobName, BigInteger peId, Integer portIndex, String metricName) {
 		boolean matches = matchesDomainId(domainId) && (_instanceFilters.size() > 0);
 		if (matches) {
 			for(InstanceFilter filter : _instanceFilters.values()) {
-				matches = filter.matchesPeOutputPortIndex(instanceId, jobName, portIndex);
+				matches = filter.matchesPeInputPortMetricName(instanceId, jobName, peId, portIndex, metricName);
 				if (matches) {
 					break;
 				}
@@ -194,11 +195,24 @@ final class DomainFilter extends PatternMatcher {
 		return matches;
 	}
 
-	public boolean matchesPeOutputPortMetricName(String domainId, String instanceId, String jobName, Integer portIndex, String metricName) {
+	public boolean matchesPeOutputPortIndex(String domainId, String instanceId, String jobName, BigInteger peId, Integer portIndex) {
 		boolean matches = matchesDomainId(domainId) && (_instanceFilters.size() > 0);
 		if (matches) {
 			for(InstanceFilter filter : _instanceFilters.values()) {
-				matches = filter.matchesPeOutputPortMetricName(instanceId, jobName, portIndex, metricName);
+				matches = filter.matchesPeOutputPortIndex(instanceId, jobName, peId, portIndex);
+				if (matches) {
+					break;
+				}
+			}
+		}
+		return matches;
+	}
+
+	public boolean matchesPeOutputPortMetricName(String domainId, String instanceId, String jobName, BigInteger peId, Integer portIndex, String metricName) {
+		boolean matches = matchesDomainId(domainId) && (_instanceFilters.size() > 0);
+		if (matches) {
+			for(InstanceFilter filter : _instanceFilters.values()) {
+				matches = filter.matchesPeOutputPortMetricName(instanceId, jobName, peId, portIndex, metricName);
 				if (matches) {
 					break;
 				}

--- a/com.ibm.streamsx.metrics/impl/java/src/com/ibm/streamsx/metrics/internal/filter/Filters.java
+++ b/com.ibm.streamsx.metrics/impl/java/src/com/ibm/streamsx/metrics/internal/filter/Filters.java
@@ -10,6 +10,7 @@ package com.ibm.streamsx.metrics.internal.filter;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.math.BigInteger;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
@@ -131,10 +132,10 @@ public class Filters {
 		return matches;
 	}
 
-	public boolean matchesPeMetricName(String domainId, String instanceId, String jobName, String metricName) {
+	public boolean matchesPeId(String domainId, String instanceId, String jobName, BigInteger peId) {
 		boolean matches = false;
 		for(DomainFilter filter : _domainFilters.values()) {
-			matches = filter.matchesPeMetricName(domainId, instanceId, jobName, metricName);
+			matches = filter.matchesPeId(domainId, instanceId, jobName, peId);
 			if (matches) {
 				break;
 			}
@@ -142,10 +143,10 @@ public class Filters {
 		return matches;
 	}
 
-	public boolean matchesPeInputPortIndex(String domainId, String instanceId, String jobName, Integer portIndex) {
+	public boolean matchesPeMetricName(String domainId, String instanceId, String jobName, BigInteger peId, String metricName) {
 		boolean matches = false;
 		for(DomainFilter filter : _domainFilters.values()) {
-			matches = filter.matchesPeInputPortIndex(domainId, instanceId, jobName, portIndex);
+			matches = filter.matchesPeMetricName(domainId, instanceId, jobName, peId, metricName);
 			if (matches) {
 				break;
 			}
@@ -153,10 +154,10 @@ public class Filters {
 		return matches;
 	}
 
-	public boolean matchesPeInputPortMetricName(String domainId, String instanceId, String jobName, Integer portIndex, String metricName) {
+	public boolean matchesPeInputPortIndex(String domainId, String instanceId, String jobName, BigInteger peId, Integer portIndex) {
 		boolean matches = false;
 		for(DomainFilter filter : _domainFilters.values()) {
-			matches = filter.matchesPeInputPortMetricName(domainId, instanceId, jobName, portIndex, metricName);
+			matches = filter.matchesPeInputPortIndex(domainId, instanceId, jobName, peId, portIndex);
 			if (matches) {
 				break;
 			}
@@ -164,10 +165,10 @@ public class Filters {
 		return matches;
 	}
 
-	public boolean matchesPeOutputPortIndex(String domainId, String instanceId, String jobName, Integer portIndex) {
+	public boolean matchesPeInputPortMetricName(String domainId, String instanceId, String jobName, BigInteger peId, Integer portIndex, String metricName) {
 		boolean matches = false;
 		for(DomainFilter filter : _domainFilters.values()) {
-			matches = filter.matchesPeOutputPortIndex(domainId, instanceId, jobName, portIndex);
+			matches = filter.matchesPeInputPortMetricName(domainId, instanceId, jobName, peId, portIndex, metricName);
 			if (matches) {
 				break;
 			}
@@ -175,10 +176,21 @@ public class Filters {
 		return matches;
 	}
 
-	public boolean matchesPeOutputPortMetricName(String domainId, String instanceId, String jobName, Integer portIndex, String metricName) {
+	public boolean matchesPeOutputPortIndex(String domainId, String instanceId, String jobName, BigInteger peId, Integer portIndex) {
 		boolean matches = false;
 		for(DomainFilter filter : _domainFilters.values()) {
-			matches = filter.matchesPeOutputPortMetricName(domainId, instanceId, jobName, portIndex, metricName);
+			matches = filter.matchesPeOutputPortIndex(domainId, instanceId, jobName, peId, portIndex);
+			if (matches) {
+				break;
+			}
+		}
+		return matches;
+	}
+
+	public boolean matchesPeOutputPortMetricName(String domainId, String instanceId, String jobName, BigInteger peId, Integer portIndex, String metricName) {
+		boolean matches = false;
+		for(DomainFilter filter : _domainFilters.values()) {
+			matches = filter.matchesPeOutputPortMetricName(domainId, instanceId, jobName, peId, portIndex, metricName);
 			if (matches) {
 				break;
 			}

--- a/com.ibm.streamsx.metrics/impl/java/src/com/ibm/streamsx/metrics/internal/filter/InstanceFilter.java
+++ b/com.ibm.streamsx.metrics/impl/java/src/com/ibm/streamsx/metrics/internal/filter/InstanceFilter.java
@@ -7,6 +7,7 @@
 
 package com.ibm.streamsx.metrics.internal.filter;
 
+import java.math.BigInteger;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -129,11 +130,11 @@ final class InstanceFilter extends PatternMatcher {
 		return matches;
 	}
 
-	public boolean matchesPeMetricName(String instanceId, String jobName, String metricName) {
+	public boolean matchesPeId(String instanceId, String jobName, BigInteger peId) {
 		boolean matches = matchesInstanceId(instanceId) && (_jobFilters.size() > 0);
 		if (matches) {
 			for(JobFilter filter : _jobFilters.values()) {
-				matches = filter.matchesPeMetricName(jobName, metricName);
+				matches = filter.matchesPeId(jobName, peId);
 				if (matches) {
 					break;
 				}
@@ -142,11 +143,11 @@ final class InstanceFilter extends PatternMatcher {
 		return matches;
 	}
 
-	public boolean matchesPeInputPortIndex(String instanceId, String jobName, Integer portIndex) {
+	public boolean matchesPeMetricName(String instanceId, String jobName, BigInteger peId, String metricName) {
 		boolean matches = matchesInstanceId(instanceId) && (_jobFilters.size() > 0);
 		if (matches) {
 			for(JobFilter filter : _jobFilters.values()) {
-				matches = filter.matchesPeInputPortIndex(jobName, portIndex);
+				matches = filter.matchesPeMetricName(jobName, peId, metricName);
 				if (matches) {
 					break;
 				}
@@ -155,11 +156,11 @@ final class InstanceFilter extends PatternMatcher {
 		return matches;
 	}
 
-	public boolean matchesPeInputPortMetricName(String instanceId, String jobName, Integer portIndex, String metricName) {
+	public boolean matchesPeInputPortIndex(String instanceId, String jobName, BigInteger peId, Integer portIndex) {
 		boolean matches = matchesInstanceId(instanceId) && (_jobFilters.size() > 0);
 		if (matches) {
 			for(JobFilter filter : _jobFilters.values()) {
-				matches = filter.matchesPeInputPortMetricName(jobName, portIndex, metricName);
+				matches = filter.matchesPeInputPortIndex(jobName, peId, portIndex);
 				if (matches) {
 					break;
 				}
@@ -168,11 +169,11 @@ final class InstanceFilter extends PatternMatcher {
 		return matches;
 	}
 
-	public boolean matchesPeOutputPortIndex(String instanceId, String jobName, Integer portIndex) {
+	public boolean matchesPeInputPortMetricName(String instanceId, String jobName, BigInteger peId, Integer portIndex, String metricName) {
 		boolean matches = matchesInstanceId(instanceId) && (_jobFilters.size() > 0);
 		if (matches) {
 			for(JobFilter filter : _jobFilters.values()) {
-				matches = filter.matchesPeOutputPortIndex(jobName, portIndex);
+				matches = filter.matchesPeInputPortMetricName(jobName, peId, portIndex, metricName);
 				if (matches) {
 					break;
 				}
@@ -181,11 +182,24 @@ final class InstanceFilter extends PatternMatcher {
 		return matches;
 	}
 
-	public boolean matchesPeOutputPortMetricName(String instanceId, String jobName, Integer portIndex, String metricName) {
+	public boolean matchesPeOutputPortIndex(String instanceId, String jobName, BigInteger peId, Integer portIndex) {
 		boolean matches = matchesInstanceId(instanceId) && (_jobFilters.size() > 0);
 		if (matches) {
 			for(JobFilter filter : _jobFilters.values()) {
-				matches = filter.matchesPeOutputPortMetricName(jobName, portIndex, metricName);
+				matches = filter.matchesPeOutputPortIndex(jobName, peId, portIndex);
+				if (matches) {
+					break;
+				}
+			}
+		}
+		return matches;
+	}
+
+	public boolean matchesPeOutputPortMetricName(String instanceId, String jobName, BigInteger peId, Integer portIndex, String metricName) {
+		boolean matches = matchesInstanceId(instanceId) && (_jobFilters.size() > 0);
+		if (matches) {
+			for(JobFilter filter : _jobFilters.values()) {
+				matches = filter.matchesPeOutputPortMetricName(jobName, peId, portIndex, metricName);
 				if (matches) {
 					break;
 				}

--- a/com.ibm.streamsx.metrics/impl/java/src/com/ibm/streamsx/metrics/internal/filter/JobFilter.java
+++ b/com.ibm.streamsx.metrics/impl/java/src/com/ibm/streamsx/metrics/internal/filter/JobFilter.java
@@ -7,6 +7,7 @@
 
 package com.ibm.streamsx.metrics.internal.filter;
 
+import java.math.BigInteger;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -125,11 +126,16 @@ final class JobFilter extends PatternMatcher {
 		return matches;
 	}
 
-	public boolean matchesPeMetricName(String jobName, String metricName) {
+	public boolean matchesPeId(String jobName, BigInteger peId) {
 		boolean matches = matchesJobName(jobName) && (_peFilters.size() > 0);
+		return matches;
+	}
+
+	public boolean matchesPeMetricName(String jobName, BigInteger peId, String metricName) {
+		boolean matches = matchesPeId(jobName, peId);
 		if (matches) {
 			for(PeFilter filter : _peFilters) {
-				matches = filter.matchesPeMetricName(metricName);
+				matches = filter.matchesPeMetricName(peId, metricName);
 				if (matches) {
 					break;
 				}
@@ -138,11 +144,11 @@ final class JobFilter extends PatternMatcher {
 		return matches;
 	}
 
-	public boolean matchesPeInputPortIndex(String jobName, Integer portIndex) {
-		boolean matches = matchesJobName(jobName) && (_peFilters.size() > 0);
+	public boolean matchesPeInputPortIndex(String jobName, BigInteger peId, Integer portIndex) {
+		boolean matches = matchesPeId(jobName, peId);
 		if (matches) {
 			for(PeFilter filter : _peFilters) {
-				matches = filter.matchesPeInputPortIndex(portIndex);
+				matches = filter.matchesPeInputPortIndex(peId, portIndex);
 				if (matches) {
 					break;
 				}
@@ -151,11 +157,11 @@ final class JobFilter extends PatternMatcher {
 		return matches;
 	}
 
-	public boolean matchesPeInputPortMetricName(String jobName, Integer portIndex, String metricName) {
-		boolean matches = matchesJobName(jobName) && (_peFilters.size() > 0);
+	public boolean matchesPeInputPortMetricName(String jobName, BigInteger peId, Integer portIndex, String metricName) {
+		boolean matches = matchesPeId(jobName, peId);
 		if (matches) {
 			for(PeFilter filter : _peFilters) {
-				matches = filter.matchesPeInputPortMetricName(portIndex, metricName);
+				matches = filter.matchesPeInputPortMetricName(peId, portIndex, metricName);
 				if (matches) {
 					break;
 				}
@@ -164,11 +170,11 @@ final class JobFilter extends PatternMatcher {
 		return matches;
 	}
 
-	public boolean matchesPeOutputPortIndex(String jobName, Integer portIndex) {
-		boolean matches = matchesJobName(jobName) && (_peFilters.size() > 0);
+	public boolean matchesPeOutputPortIndex(String jobName, BigInteger peId, Integer portIndex) {
+		boolean matches = matchesPeId(jobName, peId);
 		if (matches) {
 			for(PeFilter filter : _peFilters) {
-				matches = filter.matchesPeOutputPortIndex(portIndex);
+				matches = filter.matchesPeOutputPortIndex(peId, portIndex);
 				if (matches) {
 					break;
 				}
@@ -177,11 +183,11 @@ final class JobFilter extends PatternMatcher {
 		return matches;
 	}
 
-	public boolean matchesPeOutputPortMetricName(String jobName, Integer portIndex, String metricName) {
-		boolean matches = matchesJobName(jobName) && (_peFilters.size() > 0);
+	public boolean matchesPeOutputPortMetricName(String jobName, BigInteger peId, Integer portIndex, String metricName) {
+		boolean matches = matchesPeId(jobName, peId);
 		if (matches) {
 			for(PeFilter filter : _peFilters) {
-				matches = filter.matchesPeOutputPortMetricName(portIndex, metricName);
+				matches = filter.matchesPeOutputPortMetricName(peId, portIndex, metricName);
 				if (matches) {
 					break;
 				}

--- a/com.ibm.streamsx.metrics/impl/java/src/com/ibm/streamsx/metrics/internal/filter/PeFilter.java
+++ b/com.ibm.streamsx.metrics/impl/java/src/com/ibm/streamsx/metrics/internal/filter/PeFilter.java
@@ -7,6 +7,7 @@
 
 package com.ibm.streamsx.metrics.internal.filter;
 
+import java.math.BigInteger;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -48,7 +49,7 @@ final class PeFilter {
 		}
 	}
 
-	public boolean matchesPeMetricName(String metricName) {
+	public boolean matchesPeMetricName(BigInteger peId, String metricName) {
 		boolean matches = false;
 		for(MetricFilter filter : _metricFilters.values()) {
 			matches = filter.matchesMetricName(metricName);
@@ -59,7 +60,7 @@ final class PeFilter {
 		return matches;
 	}
 
-	public boolean matchesPeInputPortIndex(Integer portIndex) {
+	public boolean matchesPeInputPortIndex(BigInteger peId, Integer portIndex) {
 		boolean matches = false;
 		for(PortFilter filter : _inputPortFilters.values()) {
 			matches = filter.matchesPortIndex(portIndex);
@@ -70,7 +71,7 @@ final class PeFilter {
 		return matches;
 	}
 
-	public boolean matchesPeInputPortMetricName(Integer portIndex, String metricName) {
+	public boolean matchesPeInputPortMetricName(BigInteger peId, Integer portIndex, String metricName) {
 		boolean matches = false;
 		for(PortFilter filter : _inputPortFilters.values()) {
 			matches = filter.matchesPortMetricName(portIndex, metricName);
@@ -81,7 +82,7 @@ final class PeFilter {
 		return matches;
 	}
 
-	public boolean matchesPeOutputPortIndex(Integer portIndex) {
+	public boolean matchesPeOutputPortIndex(BigInteger peId, Integer portIndex) {
 		boolean matches = false;
 		for(PortFilter filter : _outputPortFilters.values()) {
 			matches = filter.matchesPortIndex(portIndex);
@@ -92,7 +93,7 @@ final class PeFilter {
 		return matches;
 	}
 
-	public boolean matchesPeOutputPortMetricName(Integer portIndex, String metricName) {
+	public boolean matchesPeOutputPortMetricName(BigInteger peId, Integer portIndex, String metricName) {
 		boolean matches = false;
 		for(PortFilter filter : _outputPortFilters.values()) {
 			matches = filter.matchesPortMetricName(portIndex, metricName);


### PR DESCRIPTION
Unify the PE handling (compared to all other filters), which means: pass
peId to all functions even if it is not compared against a pattern or
list.

Only if a PE filter is specified, add PEs to the PE handler list.

See issue #28 for more details.