### PR TITLE
[ISSUE #5] Support dynamic filter document updates

### DIFF
--- a/com.ibm.streamsx.metrics/impl/java/src/com/ibm/streamsx/metrics/internal/Closeable.java
+++ b/com.ibm.streamsx.metrics/impl/java/src/com/ibm/streamsx/metrics/internal/Closeable.java
@@ -1,0 +1,7 @@
+package com.ibm.streamsx.metrics.internal;
+
+public interface Closeable {
+
+	default void close() throws Exception {
+	}
+}

--- a/com.ibm.streamsx.metrics/impl/java/src/com/ibm/streamsx/metrics/internal/OperatorInputPortHandler.java
+++ b/com.ibm.streamsx.metrics/impl/java/src/com/ibm/streamsx/metrics/internal/OperatorInputPortHandler.java
@@ -22,7 +22,7 @@ import com.ibm.streams.management.job.OperatorInputPortMXBean;
 /**
  * 
  */
-public class OperatorInputPortHandler extends MetricOwningHandler {
+public class OperatorInputPortHandler extends MetricOwningHandler implements Closeable {
 
 	/**
 	 * Logger for tracing.

--- a/com.ibm.streamsx.metrics/impl/java/src/com/ibm/streamsx/metrics/internal/OperatorOutputPortHandler.java
+++ b/com.ibm.streamsx.metrics/impl/java/src/com/ibm/streamsx/metrics/internal/OperatorOutputPortHandler.java
@@ -22,7 +22,7 @@ import com.ibm.streams.management.job.OperatorOutputPortMXBean;
 /**
  * 
  */
-public class OperatorOutputPortHandler extends MetricOwningHandler {
+public class OperatorOutputPortHandler extends MetricOwningHandler implements Closeable {
 
 	/**
 	 * Logger for tracing.

--- a/com.ibm.streamsx.metrics/impl/java/src/com/ibm/streamsx/metrics/internal/PeInputPortHandler.java
+++ b/com.ibm.streamsx.metrics/impl/java/src/com/ibm/streamsx/metrics/internal/PeInputPortHandler.java
@@ -22,7 +22,7 @@ import com.ibm.streams.management.job.PeInputPortMXBean;
 /**
  * 
  */
-public class PeInputPortHandler extends MetricOwningHandler {
+public class PeInputPortHandler extends MetricOwningHandler implements Closeable {
 
 	/**
 	 * Logger for tracing.

--- a/com.ibm.streamsx.metrics/impl/java/src/com/ibm/streamsx/metrics/internal/PeOutputPortHandler.java
+++ b/com.ibm.streamsx.metrics/impl/java/src/com/ibm/streamsx/metrics/internal/PeOutputPortHandler.java
@@ -22,7 +22,7 @@ import com.ibm.streams.management.job.PeOutputPortMXBean;
 /**
  * 
  */
-public class PeOutputPortHandler extends MetricOwningHandler {
+public class PeOutputPortHandler extends MetricOwningHandler implements Closeable {
 
 	/**
 	 * Logger for tracing.

--- a/com.ibm.streamsx.metrics/impl/java/src/com/ibm/streamsx/metrics/internal/filter/PortParser.java
+++ b/com.ibm.streamsx.metrics/impl/java/src/com/ibm/streamsx/metrics/internal/filter/PortParser.java
@@ -12,7 +12,6 @@ import java.util.Set;
 
 import org.apache.log4j.Logger;
 
-import com.ibm.json.java.JSONArtifact;
 import com.ibm.json.java.JSONObject;
 
 public class PortParser extends AbstractParser {

--- a/samples/com.ibm.streamsx.metrics.sample.MetricsSource.ApplicationConfiguration/Makefile
+++ b/samples/com.ibm.streamsx.metrics.sample.MetricsSource.ApplicationConfiguration/Makefile
@@ -55,4 +55,9 @@ configure-incomplete:
 	# see https://www.ibm.com/support/knowledgecenter/en/SSCRJU_4.2.0/com.ibm.streams.admin.doc/doc/creating-secure-app-configs.html
 	-streamtool rmappconfig --noprompt com.ibm.streamsx.metrics.sample.MetricsSource.ApplicationConfiguration
 	streamtool mkappconfig --property user=$(USER) com.ibm.streamsx.metrics.sample.MetricsSource.ApplicationConfiguration
-	
+
+configure-memory:
+	streamtool chappconfig --property connectionURL=`streamtool getjmxconnect` --property user=$(USER) --property filterDocument=`cat etc/MetricsSource_MonitorMemoryMetrics.json | perl -e 'my @content = <STDIN>; my $$str = join("", @content); $$str =~ s/\s//g; print $$str;'` com.ibm.streamsx.metrics.sample.MetricsSource.ApplicationConfiguration
+
+configure-original:
+	streamtool chappconfig --property connectionURL=`streamtool getjmxconnect` --property user=$(USER) --property filterDocument=`cat etc/MetricsSource_MonitorOperatorMetrics.json | perl -e 'my @content = <STDIN>; my $$str = join("", @content); $$str =~ s/\s//g; print $$str;'` com.ibm.streamsx.metrics.sample.MetricsSource.ApplicationConfiguration

--- a/samples/com.ibm.streamsx.metrics.sample.MetricsSource.ApplicationConfiguration/com.ibm.streamsx.metrics.sample.MetricsSource.ApplicationConfiguration/Main.spl
+++ b/samples/com.ibm.streamsx.metrics.sample.MetricsSource.ApplicationConfiguration/com.ibm.streamsx.metrics.sample.MetricsSource.ApplicationConfiguration/Main.spl
@@ -50,17 +50,9 @@ composite Main {
 		}
 		
 		/*
-		 * Drop metric tuples that do not belong to @parallel-annotated
-		 * operators.
-		 */
-		(stream<I> ParallelizedOperatorMetrics) as UDPDetector = Filter(Notifications as I) {
-			param filter: channel != -1;
-		}
-		
-		/*
 		 * The Custom traces the received metric value notifications.
 		 */
-		() as NotificationTracer = Custom(ParallelizedOperatorMetrics as I) {
+		() as NotificationTracer = Custom(Notifications as I) {
 			logic
 			onTuple I: {
 				appTrc(Trace.error, "Notification: " + (rstring)I);

--- a/samples/com.ibm.streamsx.metrics.sample.MetricsSource.ApplicationConfiguration/etc/MetricsSource_MonitorMemoryMetrics.json
+++ b/samples/com.ibm.streamsx.metrics.sample.MetricsSource.ApplicationConfiguration/etc/MetricsSource_MonitorMemoryMetrics.json
@@ -1,0 +1,26 @@
+[
+	{
+		"domainIdPatterns":".*",
+		"instances":
+		[
+			{
+				"instanceIdPatterns":".*",
+				"jobs":
+				[
+					{
+						"jobNamePatterns":".*",
+						"pes":
+						[
+							{
+								"metricNamePatterns":
+								[
+									"n(Resident)?MemoryConsumption",
+								]
+							}
+						],
+					},
+				],
+			},
+		],
+	},
+]


### PR DESCRIPTION
Periodically check whether a filter document (JSON string) in the
application configuration changes. If it changes, invalidate all data,
load the new filters, and rescan the domain for existing instances and
jobs.