### PR TITLE
Add hint that Java 1.8 is required

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -1,3 +1,25 @@
+# Building this toolkit
+
+## Prerequisite
+
+This toolkit uses Apache Ant 1.8 (or later) to build.
+
+This toolkit requires 
+
+* IBM Streams 4.1 or later
+* Java 1.8
+
+It is recommended to use the Java version that is part of the Streams installation.
+For example, add the following commands to the `.bashrc` file:
+
+    source PATH_TO_STREAMS_INSTALLATION/bin/streamsprofile.sh
+    export JAVA_HOME=${STREAMS_INSTALL}/java
+    export PATH=${JAVA_HOME}/bin:$PATH
+
+## Build
+
+To build this toolkit run the `ant` command in this directory.
+
 For developers of this toolkit:
 
 The top-level build.xml contains two main targets:

--- a/com.ibm.streamsx.metrics/build.xml
+++ b/com.ibm.streamsx.metrics/build.xml
@@ -41,7 +41,7 @@
 	</path>
 
 	<target name="compile" depends="init">
-		<javac srcdir="${src.dir}" destdir="${build.dir}" debug="true" includeantruntime="no">
+		<javac srcdir="${src.dir}" destdir="${build.dir}" debug="true" includeantruntime="no" source="1.8" target="1.8">
 			<classpath>
 				<path refid="cp.streams" />
 			</classpath>


### PR DESCRIPTION
BUILD.md is updated and build.xml uses 1.8 target for javac
issue #36 