### PR TITLE
Support PE connection metrics

### DIFF
--- a/com.ibm.streamsx.metrics/impl/java/src/com/ibm/streamsx/metrics/internal/PeConnectionHandler.java
+++ b/com.ibm.streamsx.metrics/impl/java/src/com/ibm/streamsx/metrics/internal/PeConnectionHandler.java
@@ -1,0 +1,121 @@
+//
+//****************************************************************************
+//* Copyright (C) 2017, International Business Machines Corporation          *
+//* All rights reserved.                                                     *
+//****************************************************************************
+//
+
+package com.ibm.streamsx.metrics.internal;
+
+import org.apache.log4j.Logger;
+
+import java.math.BigInteger;
+import java.util.Set;
+
+import javax.management.JMX;
+import javax.management.ObjectName;
+
+import com.ibm.streams.management.Metric;
+import com.ibm.streams.management.ObjectNameBuilder;
+import com.ibm.streams.management.job.PeConnectionMXBean;
+
+/**
+* 
+*/
+public class PeConnectionHandler extends MetricOwningHandler implements Closeable {
+
+	/**
+	 * Logger for tracing.
+	 */
+	private static Logger _trace = Logger.getLogger(PeConnectionHandler.class.getName());
+
+	private String _domainId = null;
+
+	private String _instanceId = null;
+	
+	private BigInteger _jobId = null;
+	
+	private String _jobName = null;
+	
+	private BigInteger _peId = null;
+	
+	private String _connectionId = null;
+	
+	private PeConnectionMXBean _connection = null;
+
+	public PeConnectionHandler(OperatorConfiguration operatorConfiguration, String domainId, String instanceId, BigInteger jobId, String jobName, BigInteger peId, String connectionId) {
+
+		super(MetricsRegistrationMode.DynamicMetricsRegistration);
+
+		// Determine the trace level status once per function.
+		boolean isDebugEnabled = _trace.isDebugEnabled();
+
+		// Store parameters for later use.
+		_operatorConfiguration = operatorConfiguration;
+		_domainId = domainId;
+		_instanceId = instanceId;
+		_jobId = jobId;
+		_jobName = jobName;
+		_peId = peId;
+		_connectionId = connectionId;
+
+		if (isDebugEnabled) {
+			_trace.debug("--> ConnectionHandler(domain=" + _domainId + ", instance=" + _instanceId + ", job=[" + _jobId + "]:" + _jobName + ", peId=" + _peId + ", connectionId=" + _connectionId + ")");
+		}
+		
+		ObjectName objName = ObjectNameBuilder.peConnection(_domainId, _instanceId, _connectionId);
+		_connection = JMX.newMXBeanProxy(_operatorConfiguration.get_mbeanServerConnection(), objName, PeConnectionMXBean.class, true);
+		
+		/*
+		 * Register connection metrics that match the specified filter criteria.
+		 */
+		registerMetrics();
+		
+		if (isDebugEnabled) {
+			_trace.debug("<-- PeConnectionHandler(domain=" + _domainId + ", instance=" + _instanceId + ", job=[" + _jobId + "]:" + _jobName + ", peId=" + _peId + ", connectionId=" + _connectionId + ")");
+		}
+	}
+
+	@Override
+	protected boolean isRelevantMetric(String metricName) {
+		boolean isRelevant = _operatorConfiguration.get_filters().matchesPeConnectionMetricName(_domainId, _instanceId, _jobName, _peId, _connectionId, metricName);
+		if (_trace.isInfoEnabled()) {
+			if (isRelevant) {
+				_trace.info("The following input port metric meets the filter criteria and is therefore, monitored: domain=" + _domainId + ", instance=" + _instanceId + ", job=[" + _jobId + "][" + _jobName + "], peId=" + _peId + ", connectionId=" + _connectionId + ", metric=" + metricName);
+			}
+			else { 
+				_trace.info("The following input port metric does not meet the filter criteria and is therefore, not monitored: domain=" + _domainId + ", instance=" + _instanceId + ", job=[" + _jobId + "][" + _jobName + "], peId=" + _peId + ", connetionId=" + _connectionId + ", metric=" + metricName);
+			}
+		}
+		return isRelevant;
+	}
+
+	@Override
+	protected Set<Metric> retrieveMetrics() {
+		Set<Metric> metrics = _connection.retrieveMetrics();
+		return metrics;
+	}
+
+	/**
+	 * Iterate all jobs to capture the job metrics.
+	 * @throws Exception 
+	 */
+	public void captureMetrics() throws Exception {
+
+		// Determine the trace level status once per function.
+		boolean isDebugEnabled = _trace.isDebugEnabled();
+
+		if (isDebugEnabled) {
+			_trace.debug("--> captureMetrics(domain=" + _domainId + ", instance=" + _instanceId + ", job=[" + _jobId + "]:" + _jobName + ", peId=" + _peId + ", connectionId=" + _connectionId + ")");
+		}
+
+		_operatorConfiguration.get_tupleContainer().setOrigin("PeConnectionId");
+		_operatorConfiguration.get_tupleContainer().setConnectionId(_connectionId);
+		captureAndSubmitChangedMetrics();
+
+		if (isDebugEnabled) {
+			_trace.debug("<-- captureMetrics(domain=" + _domainId + ", instance=" + _instanceId + ", job=[" + _jobId + "]:" + _jobName + ", peId=" + _peId + ", connectionId=" + _connectionId + ")");
+		}
+	}
+
+}

--- a/com.ibm.streamsx.metrics/impl/java/src/com/ibm/streamsx/metrics/internal/PeHandler.java
+++ b/com.ibm.streamsx.metrics/impl/java/src/com/ibm/streamsx/metrics/internal/PeHandler.java
@@ -54,6 +54,8 @@ public class PeHandler extends MetricOwningHandler implements NotificationListen
 	private Map<Integer /* port index */, PeInputPortHandler> _inputPortHandlers = new HashMap<>();
 
 	private Map<Integer /* port index */, PeOutputPortHandler> _outputPortHandlers = new HashMap<>();
+	
+	private Map<String /* connection id */, PeConnectionHandler> _connectionHandlers = new HashMap<>();
 
 	public PeHandler(OperatorConfiguration operatorConfiguration, String domainId, String instanceId, BigInteger jobId, String jobName, BigInteger peId) {
 
@@ -104,6 +106,11 @@ public class PeHandler extends MetricOwningHandler implements NotificationListen
 		for (Integer portIndex : _pe.getOutputPorts()) {
 			addValidOutputPort(portIndex);
 		}
+		
+		for (String connectionId : _pe.getConnections()) {
+			addValidConnection(connectionId);
+		}
+		
 	}
 
 	/**
@@ -165,6 +172,22 @@ public class PeHandler extends MetricOwningHandler implements NotificationListen
 			_outputPortHandlers.put(portIndex, new PeOutputPortHandler(_operatorConfiguration, _domainId, _instanceId, _jobId, _jobName, _peId, portIndex));
 		}
 	}
+	
+	protected void addValidConnection(String connectionId) {
+//		boolean matches = _operatorConfiguration.get_filters().matchesPeOutputPortIndex(_domainId, _instanceId, _jobName, _peId, portIndex);
+//		if (_trace.isInfoEnabled()) {
+//			if (matches) {
+//				_trace.info("The following output port meets the filter criteria and is therefore, monitored: domain=" + _domainId + ", instance=" + _instanceId + ", job=[" + _jobId + "][" + _jobName + "], peId=" + _peId + ", port=" + portIndex);
+//			}
+//			else {
+//				_trace.info("The following output port does not meet the filter criteria and is therefore, not monitored: domain=" + _domainId + ", instance=" + _instanceId + ", job=[" + _jobId + "][" + _jobName + "], peId=" + _peId + ", port=" + portIndex);
+//			}
+//		}
+//		if (matches) {
+		if (true) {
+			_connectionHandlers.put(connectionId, new PeConnectionHandler(_operatorConfiguration, _domainId, _instanceId, _jobId, _jobName, _peId, connectionId));
+		}
+	}
 
 	/**
 	 * Iterate all jobs to capture the job metrics.
@@ -197,6 +220,9 @@ public class PeHandler extends MetricOwningHandler implements NotificationListen
 		}
 		for(Integer portIndex : _outputPortHandlers.keySet()) {
 			_outputPortHandlers.get(portIndex).captureMetrics();
+		}
+		for(String connectionId : _connectionHandlers.keySet()) {
+			_connectionHandlers.get(connectionId).captureMetrics();
 		}
 
 		if (isDebugEnabled) {

--- a/com.ibm.streamsx.metrics/impl/java/src/com/ibm/streamsx/metrics/internal/TupleContainer.java
+++ b/com.ibm.streamsx.metrics/impl/java/src/com/ibm/streamsx/metrics/internal/TupleContainer.java
@@ -60,6 +60,11 @@ public class TupleContainer {
 	private Integer _portIndexAttributeIndex = null;
 	
 	/**
+	 * Index of the connectionId attribute.
+	 */
+	private Integer _connectionIdAttributeIndex = null;
+	
+	/**
 	 * Index of the channel attribute.
 	 */
 	private Integer _channelAttributeIndex = null;
@@ -156,6 +161,11 @@ public class TupleContainer {
 		if (_portIndexAttributeIndex == null) {
 			Attribute attribute = schema.getAttribute("portIndex");
 			_portIndexAttributeIndex = Integer.valueOf(attribute != null && attribute.getType().getMetaType() == Type.MetaType.INT32 ? attribute.getIndex() : -1) ;
+		}
+		// Connection-related attributes.
+		if (_connectionIdAttributeIndex == null) {
+			Attribute attribute = schema.getAttribute("connectionId");
+			_connectionIdAttributeIndex = Integer.valueOf(attribute != null && attribute.getType().getMetaType() == Type.MetaType.RSTRING ? attribute.getIndex() : -1) ;
 		}
 		// Metric-related attributes.
 		if (_originAttributeIndex == null) {
@@ -258,6 +268,17 @@ public class TupleContainer {
 	public void setPortIndex(int portIndex) {
 		if (_portIndexAttributeIndex != -1) {
 			_tuple.setInt(_portIndexAttributeIndex, portIndex);
+		}
+	}
+	
+	/**
+	 * Optionally set the connection id in the output tuple.
+	 * 
+	 * @param connectionId
+	 */
+	public void setConnectionId(String connectionId) {
+		if (_connectionIdAttributeIndex != -1) {
+			_tuple.setString(_connectionIdAttributeIndex, connectionId);
 		}
 	}
 

--- a/com.ibm.streamsx.metrics/impl/java/src/com/ibm/streamsx/metrics/internal/filter/ConnectionFilter.java
+++ b/com.ibm.streamsx.metrics/impl/java/src/com/ibm/streamsx/metrics/internal/filter/ConnectionFilter.java
@@ -1,0 +1,54 @@
+//
+// ****************************************************************************
+// * Copyright (C) 2016, 2017, International Business Machines Corporation    *
+// * All rights reserved.                                                     *
+// ****************************************************************************
+//
+
+package com.ibm.streamsx.metrics.internal.filter;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.PatternSyntaxException;
+
+import org.apache.log4j.Logger;
+
+public class ConnectionFilter extends PatternMatcher {
+
+	/**
+	 * Logger for tracing.
+	 */
+	private static Logger _trace = Logger.getLogger(ConnectionFilter.class.getName());
+
+	/**
+	 * A port has many metrics.
+	 */
+	protected Map<String /* regular expression */, MetricFilter> _metricFilters = new HashMap<>();
+
+	public ConnectionFilter(String connectionId, Set<MetricFilter> metricFilters) throws PatternSyntaxException {
+		super(connectionId);
+		for(MetricFilter metricFilter : metricFilters) {
+			_metricFilters.put(metricFilter.getRegularExpression(), metricFilter);
+		}
+	}
+
+	public boolean matchesConnectionId(String connectionId) {
+		boolean matches = matches(connectionId);
+		return matches;
+	}
+
+	public boolean matchesConnectionMetricName(String connectionId, String metricName) {
+		boolean matches = matchesConnectionId(connectionId) && (_metricFilters.size() > 0);
+		if (matches) {
+			for(MetricFilter filter : _metricFilters.values()) {
+				matches = filter.matchesMetricName(metricName);
+				if (matches) {
+					break;
+				}
+			}
+		}
+		return matches;
+	}
+
+}

--- a/com.ibm.streamsx.metrics/impl/java/src/com/ibm/streamsx/metrics/internal/filter/ConnectionParser.java
+++ b/com.ibm.streamsx.metrics/impl/java/src/com/ibm/streamsx/metrics/internal/filter/ConnectionParser.java
@@ -1,0 +1,72 @@
+//
+// ****************************************************************************
+// * Copyright (C) 2016, 2017, International Business Machines Corporation    *
+// * All rights reserved.                                                     *
+// ****************************************************************************
+//
+
+package com.ibm.streamsx.metrics.internal.filter;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.apache.log4j.Logger;
+
+import com.ibm.json.java.JSONObject;
+
+public class ConnectionParser extends AbstractParser {
+	private static Logger _logger = Logger.getLogger(PortParser.class.getName());
+
+	private static final String CONNECTION_ID_PATTERNS = "connectionIdPatterns";
+
+	private static final String METRIC_NAME_PATTERNS = "metricNamePatterns";
+
+	protected ConnectionParser() {
+
+		setMandatoryItem(METRIC_NAME_PATTERNS);
+
+		setValidationRule(CONNECTION_ID_PATTERNS, new IValidator() {
+
+			@Override
+			public boolean validate(String key, Object object) {
+				return verifyPatterns(key, object);
+			}
+			
+		});
+
+		setValidationRule(METRIC_NAME_PATTERNS, new IValidator() {
+
+			@Override
+			public boolean validate(String key, Object object) {
+				return verifyPatterns(key, object);
+			}
+			
+		});
+
+	}
+
+	@Override
+	protected Logger logger() {
+		return _logger;
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	protected Set<ConnectionFilter> buildFilters(JSONObject json) {
+//		logger().error("ConnectionParser.JSON=" + json);
+		Set<String> patterns = buildPatternList(json.get(CONNECTION_ID_PATTERNS));
+		Set<String> metrics = buildPatternList(json.get(METRIC_NAME_PATTERNS));
+		Set<MetricFilter> metricFilters = new HashSet<>();
+		for (String pattern : metrics) {
+//			logger().error("create metric filter, pattern=" + pattern);
+			metricFilters.add(new MetricFilter(pattern));
+		}
+		Set<ConnectionFilter> result = new HashSet<>();
+		for (String pattern : patterns) {
+//			logger().error("create connection filter, connectionId=" + pattern);
+			result.add(new ConnectionFilter(pattern, metricFilters));
+		}
+		return result;
+	}
+
+}

--- a/com.ibm.streamsx.metrics/impl/java/src/com/ibm/streamsx/metrics/internal/filter/DomainFilter.java
+++ b/com.ibm.streamsx.metrics/impl/java/src/com/ibm/streamsx/metrics/internal/filter/DomainFilter.java
@@ -220,5 +220,18 @@ final class DomainFilter extends PatternMatcher {
 		}
 		return matches;
 	}
+	
+	public boolean matchesPeConnectionMetricName(String domainId, String instanceId, String jobName, BigInteger peId, String connectionId, String metricName) {
+		boolean matches = matchesDomainId(domainId) && (_instanceFilters.size() > 0);
+		if (matches) {
+			for(InstanceFilter filter : _instanceFilters.values()) {
+				matches = filter.matchesPeConnectionMetricName(instanceId, jobName, peId, connectionId, metricName);
+				if (matches) {
+					break;
+				}
+			}
+		}
+		return matches;
+	}
 
 }

--- a/com.ibm.streamsx.metrics/impl/java/src/com/ibm/streamsx/metrics/internal/filter/Filters.java
+++ b/com.ibm.streamsx.metrics/impl/java/src/com/ibm/streamsx/metrics/internal/filter/Filters.java
@@ -197,6 +197,17 @@ public class Filters {
 		}
 		return matches;
 	}
+	
+	public boolean matchesPeConnectionMetricName(String domainId, String instanceId, String jobName, BigInteger peId, String connectionId, String metricName) {
+		boolean matches = false;
+		for(DomainFilter filter : _domainFilters.values()) {
+			matches = filter.matchesPeConnectionMetricName(domainId, instanceId, jobName, peId, connectionId, metricName);
+			if (matches) {
+				break;
+			}
+		}
+		return matches;
+	}
 
 	/**
 	 * Read the filterDocument file, parse its JSON-formatted content, and

--- a/com.ibm.streamsx.metrics/impl/java/src/com/ibm/streamsx/metrics/internal/filter/InstanceFilter.java
+++ b/com.ibm.streamsx.metrics/impl/java/src/com/ibm/streamsx/metrics/internal/filter/InstanceFilter.java
@@ -207,5 +207,18 @@ final class InstanceFilter extends PatternMatcher {
 		}
 		return matches;
 	}
+	
+	public boolean matchesPeConnectionMetricName(String instanceId, String jobName, BigInteger peId, String peConnection, String metricName) {
+		boolean matches = matchesInstanceId(instanceId) && (_jobFilters.size() > 0);
+		if (matches) {
+			for(JobFilter filter : _jobFilters.values()) {
+				matches = filter.matchesPeConnectionMetricName(jobName, peId, peConnection, metricName);
+				if (matches) {
+					break;
+				}
+			}
+		}
+		return matches;
+	}
 
 }

--- a/com.ibm.streamsx.metrics/impl/java/src/com/ibm/streamsx/metrics/internal/filter/JobFilter.java
+++ b/com.ibm.streamsx.metrics/impl/java/src/com/ibm/streamsx/metrics/internal/filter/JobFilter.java
@@ -195,5 +195,18 @@ final class JobFilter extends PatternMatcher {
 		}
 		return matches;
 	}
+	
+	public boolean matchesPeConnectionMetricName(String jobName, BigInteger peId, String connectionId, String metricName) {
+		boolean matches = matchesPeId(jobName, peId);
+		if (matches) {
+			for(PeFilter filter : _peFilters) {
+				matches = filter.matchesPeConnectionMetricName(peId, connectionId, metricName);
+				if (matches) {
+					break;
+				}
+			}
+		}
+		return matches;
+	}
 
 }

--- a/com.ibm.streamsx.metrics/impl/java/src/com/ibm/streamsx/metrics/internal/filter/PeFilter.java
+++ b/com.ibm.streamsx.metrics/impl/java/src/com/ibm/streamsx/metrics/internal/filter/PeFilter.java
@@ -36,8 +36,13 @@ final class PeFilter {
 	 * An operator has many output ports.
 	 */
 	protected Map<Long /* port index */, PortFilter> _outputPortFilters = new HashMap<>();
+	
+	/**
+	 * A PE has many connections.
+	 */
+	protected Map<String /* connection id */, ConnectionFilter> _connectionFilters = new HashMap<>();
 
-	public PeFilter(Set<MetricFilter> metricFilters, Set<PortFilter> inputPortFilters, Set<PortFilter> outputPortFilters) throws PatternSyntaxException {
+	public PeFilter(Set<MetricFilter> metricFilters, Set<PortFilter> inputPortFilters, Set<PortFilter> outputPortFilters, Set<ConnectionFilter> connectionFilters) throws PatternSyntaxException {
 		for(MetricFilter metricFilter : metricFilters) {
 			_metricFilters.put(metricFilter.getRegularExpression(), metricFilter);
 		}
@@ -46,6 +51,9 @@ final class PeFilter {
 		}
 		for(PortFilter portFilter : outputPortFilters) {
 			_outputPortFilters.put(portFilter.getNumber(), portFilter);
+		}
+		for(ConnectionFilter connectionFilter : connectionFilters) {
+			_connectionFilters.put(connectionFilter.getRegularExpression(), connectionFilter);
 		}
 	}
 
@@ -97,6 +105,17 @@ final class PeFilter {
 		boolean matches = false;
 		for(PortFilter filter : _outputPortFilters.values()) {
 			matches = filter.matchesPortMetricName(portIndex, metricName);
+			if (matches) {
+				break;
+			}
+		}
+		return matches;
+	}
+	
+	public boolean matchesPeConnectionMetricName(BigInteger peId, String peConnection, String metricName) {
+		boolean matches = false;
+		for(ConnectionFilter filter : _connectionFilters.values()) {
+			matches = filter.matchesConnectionMetricName(peConnection, metricName);
 			if (matches) {
 				break;
 			}

--- a/com.ibm.streamsx.metrics/impl/java/src/com/ibm/streamsx/metrics/internal/filter/PeParser.java
+++ b/com.ibm.streamsx.metrics/impl/java/src/com/ibm/streamsx/metrics/internal/filter/PeParser.java
@@ -24,8 +24,12 @@ public class PeParser extends AbstractParser {
 	private static final String INPUT_PORTS = "inputPorts";
 
 	private static final String OUTPUT_PORTS = "outputPorts";
+	
+	private static final String CONNECTIONS = "connections";
 
 	private PortParser _portParser = new PortParser();
+	
+	private ConnectionParser _connectionParser = new ConnectionParser();
 	
 	protected PeParser() {
 
@@ -71,6 +75,23 @@ public class PeParser extends AbstractParser {
 			}
 			
 		});
+		
+		setValidationRule(CONNECTIONS, new IValidator() {
+
+			@Override
+			public boolean validate(String key, Object object) {
+				boolean result = true;
+				if (object instanceof JSONArtifact) {
+					result = _connectionParser.validate((JSONArtifact)object);
+				}
+				else {
+					result = false;
+					logger().error("filterDocument: The parsed object must be a JSONArtifact. Details: key=" + key + ", object=" + object);
+				}
+				return result;
+			}
+			
+		});
 	}
 
 	@Override
@@ -85,6 +106,7 @@ public class PeParser extends AbstractParser {
 		Set<String> metrics = buildPatternList(json.get(METRIC_NAME_PATTERNS));
 		Set<PortFilter> inputPortFilters = _portParser.buildFilters((JSONArtifact)json.get(INPUT_PORTS));
 		Set<PortFilter> outputPortFilters = _portParser.buildFilters((JSONArtifact)json.get(OUTPUT_PORTS));
+		Set<ConnectionFilter> connectionFilters = _connectionParser.buildFilters((JSONArtifact)json.get(CONNECTIONS));
 		Set<MetricFilter> metricFilters = new HashSet<>();
 		for (String pattern : metrics) {
 //			logger().error("create metric filter, pattern=" + pattern);
@@ -92,7 +114,7 @@ public class PeParser extends AbstractParser {
 		}
 		Set<PeFilter> result = new HashSet<>();
 //		logger().error("create PE filter");
-		result.add(new PeFilter(metricFilters, inputPortFilters, outputPortFilters));
+		result.add(new PeFilter(metricFilters, inputPortFilters, outputPortFilters, connectionFilters));
 		return result;
 	}
 

--- a/samples/com.ibm.streamsx.metrics.sample.test/etc/MetricsSource_MonitorEverything.json
+++ b/samples/com.ibm.streamsx.metrics.sample.test/etc/MetricsSource_MonitorEverything.json
@@ -27,6 +27,13 @@
 										"metricNamePatterns":".*",
 									},
 								],
+								"connections":
+								[
+									{
+										"connectionIdPatterns":".*",
+										"metricNamePatterns":".*"
+									},
+								],
 							}
 						],
 						"operators":


### PR DESCRIPTION
PE connection metrics are missing. These include congestionFactor and nTuplesFilteredOut - the former being an extremely useful metric for monitoring purposes.

Supports the same filtering rules as PE port metrics. I added a rule to samples/com.ibm.streamsx.metrics.sample.test/etc/MetricsSource_MonitorEverything.json, for reference.