### PR TITLE
Add PE connectionIdPatterns handlers

### DIFF
--- a/com.ibm.streamsx.metrics/com.ibm.streamsx.metrics/Types.spl
+++ b/com.ibm.streamsx.metrics/com.ibm.streamsx.metrics/Types.spl
@@ -55,6 +55,12 @@ public composite Origin {
 		 *   number of submitted tuples or markers. The portIndex attribute
 		 *   specifies the index of the port.
 		 * 
+		 * * **PeConnection**
+		 * 
+		 *   A PE's output port has connection metrics that describe, for 
+		 * 	 example, the congestionFactor or nTuplesFilteredOut. The connectionId 
+		 *   attribute specifies the ID of the PE connection.
+		 * 
 		 * See [http://www.ibm.com/support/knowledgecenter/en/SSCRJU_4.2.0/com.ibm.streams.dev.doc/doc/metricaccess.html|Metrics Access]
 		 * in IBM's Knowledge Center for further details.
 		 */
@@ -65,7 +71,7 @@ public composite Origin {
 			Pe,
 			PeInputPort,
 			PeOutputPort,
-			PeConnectionId
+			PeConnection
 		};
 }
 
@@ -143,6 +149,11 @@ public composite Origin {
  *   If the metric belongs to an input or output port, the attribute holds the
  *   index of this port. Else, the attribute is set to 0.
  * 
+ * * **connectionId**
+ * 
+ *   If the metric belongs to a connection, the attribute holds the
+ *   ID of this connection.
+ * 
  * * **metricType**
  * 
  *   A string that identifies the type of metric. Some possible values for this
@@ -178,6 +189,7 @@ type Notification = tuple<
 	rstring operatorName,
 	int32 channel,
 	int32 portIndex,
+	rstring connectionId,
 	rstring metricType,
 	rstring metricKind,
 	rstring metricName,

--- a/com.ibm.streamsx.metrics/impl/java/src/com/ibm/streamsx/metrics/internal/PeConnectionHandler.java
+++ b/com.ibm.streamsx.metrics/impl/java/src/com/ibm/streamsx/metrics/internal/PeConnectionHandler.java
@@ -109,7 +109,7 @@ public class PeConnectionHandler extends MetricOwningHandler implements Closeabl
 			_trace.debug("--> captureMetrics(domain=" + _domainId + ", instance=" + _instanceId + ", job=[" + _jobId + "]:" + _jobName + ", peId=" + _peId + ", connectionId=" + _connectionId + ")");
 		}
 
-		_operatorConfiguration.get_tupleContainer().setOrigin("PeConnectionId");
+		_operatorConfiguration.get_tupleContainer().setOrigin("PeConnection");
 		_operatorConfiguration.get_tupleContainer().setConnectionId(_connectionId);
 		captureAndSubmitChangedMetrics();
 

--- a/com.ibm.streamsx.metrics/impl/java/src/com/ibm/streamsx/metrics/internal/PeHandler.java
+++ b/com.ibm.streamsx.metrics/impl/java/src/com/ibm/streamsx/metrics/internal/PeHandler.java
@@ -174,17 +174,16 @@ public class PeHandler extends MetricOwningHandler implements NotificationListen
 	}
 	
 	protected void addValidConnection(String connectionId) {
-//		boolean matches = _operatorConfiguration.get_filters().matchesPeOutputPortIndex(_domainId, _instanceId, _jobName, _peId, portIndex);
-//		if (_trace.isInfoEnabled()) {
-//			if (matches) {
-//				_trace.info("The following output port meets the filter criteria and is therefore, monitored: domain=" + _domainId + ", instance=" + _instanceId + ", job=[" + _jobId + "][" + _jobName + "], peId=" + _peId + ", port=" + portIndex);
-//			}
-//			else {
-//				_trace.info("The following output port does not meet the filter criteria and is therefore, not monitored: domain=" + _domainId + ", instance=" + _instanceId + ", job=[" + _jobId + "][" + _jobName + "], peId=" + _peId + ", port=" + portIndex);
-//			}
-//		}
-//		if (matches) {
-		if (true) {
+		boolean matches = _operatorConfiguration.get_filters().matchesPeConnectionId(_domainId, _instanceId, _jobName, _peId, connectionId);
+		if (_trace.isInfoEnabled()) {
+			if (matches) {
+				_trace.info("The following output port meets the filter criteria and is therefore, monitored: domain=" + _domainId + ", instance=" + _instanceId + ", job=[" + _jobId + "][" + _jobName + "], peId=" + _peId + ", connection=" + connectionId);
+			}
+			else {
+				_trace.info("The following output port does not meet the filter criteria and is therefore, not monitored: domain=" + _domainId + ", instance=" + _instanceId + ", job=[" + _jobId + "][" + _jobName + "], peId=" + _peId + ", connection=" + connectionId);
+			}
+		}
+		if (matches) {
 			_connectionHandlers.put(connectionId, new PeConnectionHandler(_operatorConfiguration, _domainId, _instanceId, _jobId, _jobName, _peId, connectionId));
 		}
 	}

--- a/com.ibm.streamsx.metrics/impl/java/src/com/ibm/streamsx/metrics/internal/filter/DomainFilter.java
+++ b/com.ibm.streamsx.metrics/impl/java/src/com/ibm/streamsx/metrics/internal/filter/DomainFilter.java
@@ -221,6 +221,19 @@ final class DomainFilter extends PatternMatcher {
 		return matches;
 	}
 	
+	public boolean matchesPeConnectionId(String domainId, String instanceId, String jobName, BigInteger peId, String connectionId) {
+		boolean matches = matchesDomainId(domainId) && (_instanceFilters.size() > 0);
+		if (matches) {
+			for(InstanceFilter filter : _instanceFilters.values()) {
+				matches = filter.matchesPeConnectionId(instanceId, jobName, peId, connectionId);
+				if (matches) {
+					break;
+				}
+			}
+		}
+		return matches;
+	}
+	
 	public boolean matchesPeConnectionMetricName(String domainId, String instanceId, String jobName, BigInteger peId, String connectionId, String metricName) {
 		boolean matches = matchesDomainId(domainId) && (_instanceFilters.size() > 0);
 		if (matches) {

--- a/com.ibm.streamsx.metrics/impl/java/src/com/ibm/streamsx/metrics/internal/filter/Filters.java
+++ b/com.ibm.streamsx.metrics/impl/java/src/com/ibm/streamsx/metrics/internal/filter/Filters.java
@@ -198,6 +198,17 @@ public class Filters {
 		return matches;
 	}
 	
+	public boolean matchesPeConnectionId(String domainId, String instanceId, String jobName, BigInteger peId, String connectionId) {
+		boolean matches = false;
+		for(DomainFilter filter : _domainFilters.values()) {
+			matches = filter.matchesPeConnectionId(domainId, instanceId, jobName, peId, connectionId);
+			if (matches) {
+				break;
+			}
+		}
+		return matches;
+	}
+	
 	public boolean matchesPeConnectionMetricName(String domainId, String instanceId, String jobName, BigInteger peId, String connectionId, String metricName) {
 		boolean matches = false;
 		for(DomainFilter filter : _domainFilters.values()) {

--- a/com.ibm.streamsx.metrics/impl/java/src/com/ibm/streamsx/metrics/internal/filter/InstanceFilter.java
+++ b/com.ibm.streamsx.metrics/impl/java/src/com/ibm/streamsx/metrics/internal/filter/InstanceFilter.java
@@ -208,6 +208,19 @@ final class InstanceFilter extends PatternMatcher {
 		return matches;
 	}
 	
+	public boolean matchesPeConnectionId(String instanceId, String jobName, BigInteger peId, String connectionId) {
+		boolean matches = matchesInstanceId(instanceId) && (_jobFilters.size() > 0);
+		if (matches) {
+			for(JobFilter filter : _jobFilters.values()) {
+				matches = filter.matchesPeConnectionId(jobName, peId, connectionId);
+				if (matches) {
+					break;
+				}
+			}
+		}
+		return matches;
+	}
+	
 	public boolean matchesPeConnectionMetricName(String instanceId, String jobName, BigInteger peId, String peConnection, String metricName) {
 		boolean matches = matchesInstanceId(instanceId) && (_jobFilters.size() > 0);
 		if (matches) {

--- a/com.ibm.streamsx.metrics/impl/java/src/com/ibm/streamsx/metrics/internal/filter/JobFilter.java
+++ b/com.ibm.streamsx.metrics/impl/java/src/com/ibm/streamsx/metrics/internal/filter/JobFilter.java
@@ -196,6 +196,19 @@ final class JobFilter extends PatternMatcher {
 		return matches;
 	}
 	
+	public boolean matchesPeConnectionId(String jobName, BigInteger peId, String connectionId) {
+		boolean matches = matchesPeId(jobName, peId);
+		if (matches) {
+			for(PeFilter filter : _peFilters) {
+				matches = filter.matchesPeConnectionId(peId, connectionId);
+				if (matches) {
+					break;
+				}
+			}
+		}
+		return matches;
+	}
+	
 	public boolean matchesPeConnectionMetricName(String jobName, BigInteger peId, String connectionId, String metricName) {
 		boolean matches = matchesPeId(jobName, peId);
 		if (matches) {

--- a/com.ibm.streamsx.metrics/impl/java/src/com/ibm/streamsx/metrics/internal/filter/PeFilter.java
+++ b/com.ibm.streamsx.metrics/impl/java/src/com/ibm/streamsx/metrics/internal/filter/PeFilter.java
@@ -112,6 +112,17 @@ final class PeFilter {
 		return matches;
 	}
 	
+	public boolean matchesPeConnectionId(BigInteger peId, String connectionId) {
+		boolean matches = false;
+		for(ConnectionFilter filter : _connectionFilters.values()) {
+			matches = filter.matchesConnectionId(connectionId);
+			if (matches) {
+				break;
+			}
+		}
+		return matches;
+	}
+	
 	public boolean matchesPeConnectionMetricName(BigInteger peId, String peConnection, String metricName) {
 		boolean matches = false;
 		for(ConnectionFilter filter : _connectionFilters.values()) {


### PR DESCRIPTION
I forgot to add filter-checking for PE connectionIdPatterns. I only added them for PE metricNamePatterns.