### PR TITLE
Provide MetricsIngestService

### DIFF
--- a/com.ibm.streamsx.metrics/com.ibm.streamsx.metrics.service/MetricsIngestService.spl
+++ b/com.ibm.streamsx.metrics/com.ibm.streamsx.metrics.service/MetricsIngestService.spl
@@ -45,25 +45,24 @@ public composite MetricsIngestService
 		/**
 		 * The MetricsSource generates a tuple for each retrieved metric.
 		 */
-		stream<Notification> MetricsSource_0 = MetricsSource()
+		stream<Notification> Metrics = MetricsSource()
 		{
 			param
 				applicationConfigurationName : $applicationConfigurationName ;
-				emitMetricTuple : periodic ;
 		}
 
 		/**
-		 * The TupleToJSON converts the MetricType tuples into JSON.
+		 * The TupleToJSON converts the Metrics tuples into JSON format.
 		 */
-		stream<rstring jsonString> TupleToJSON_0 = TupleToJSON(MetricsSource_0)
+		stream<rstring jsonString> JsonMetrics = TupleToJSON(Metrics)
 		{
 		
 		}
 		
 		/**
-		 * The Publish publishes the metrics JSON string to the 'streamsx/metrics/ingest' topic.
+		 * The Publish publishes the JsonMetrics to the specified topic.
 		 */
-		() as Publish_0 = Publish(TupleToJSON_0)
+		() as Publish_0 = Publish(JsonMetrics)
 		{
 			param
 				topic : $topic ;

--- a/com.ibm.streamsx.metrics/com.ibm.streamsx.metrics.service/MetricsIngestService.spl
+++ b/com.ibm.streamsx.metrics/com.ibm.streamsx.metrics.service/MetricsIngestService.spl
@@ -10,7 +10,7 @@
  * operator's tuples in JSON format to the a specified topic.
  * 
  * Output JSON Schema:
- * {
+ * \{
  *   "domainId" : string,
  *   "instanceId" : string,
  *   "jobId" : string,
@@ -26,7 +26,7 @@
  *   "metricName" : string,
  *   "metricValue" : long,
  *   "lastTimeRetrieved" : long
- * }
+ * \}
  */
  
 namespace com.ibm.streamsx.metrics.service;

--- a/com.ibm.streamsx.metrics/com.ibm.streamsx.metrics.service/MetricsIngestService.spl
+++ b/com.ibm.streamsx.metrics/com.ibm.streamsx.metrics.service/MetricsIngestService.spl
@@ -8,7 +8,7 @@
 /**
  * A metrics ingest service for the 
  * [com.ibm.streamsx.metrics::MetricsSource] operator.
- * Converts tuples to JSON and publishes it to 'ingest-metrics' topic.
+ * Converts tuples to JSON and publishes it to 'streamsx/metrics/ingest' topic.
  */
  
 namespace com.ibm.streamsx.metrics.service;
@@ -45,11 +45,11 @@ public composite MetricsIngestService
 		stream<MetricType> MetricsSource_0 = MetricsSource()
 		{
 			param
-				applicationConfigurationName: $applicationConfigurationName;
+				applicationConfigurationName : $applicationConfigurationName ;
 		}
 
 		/**
-		 * The TupleToJSON converts the MetricType tuples into JSON format.
+		 * The TupleToJSON converts the MetricType tuples into JSON.
 		 */
 		stream<rstring jsonString> TupleToJSON_0 = TupleToJSON(MetricsSource_0)
 		{
@@ -57,11 +57,11 @@ public composite MetricsIngestService
 		}
 		
 		/**
-		 * The Export publishes the MetricType JSON string to the 'ingest-metrics' topic.
+		 * The Export publishes the MetricType JSON string to the 'streamsx/metrics/ingest' topic.
 		 */
 		() as Export_0 = Export(TupleToJSON_0)
 		{
 			param
-				properties: { topic = "ingest-metrics" };
+				properties : { topic = "streamsx/metrics/ingest" } ;
 		}
 }

--- a/com.ibm.streamsx.metrics/com.ibm.streamsx.metrics.service/MetricsIngestService.spl
+++ b/com.ibm.streamsx.metrics/com.ibm.streamsx.metrics.service/MetricsIngestService.spl
@@ -38,7 +38,8 @@ use com.ibm.streamsx.topology.topic::Publish ;
 public composite MetricsIngestService
 {			
 	param
-		expression<rstring> $applicationConfigurationName ;
+		expression<rstring> $applicationConfigurationName : getSubmissionTimeValue("applicationConfigurationName", "metricsConfig");
+		expression<rstring> $topic : getSubmissionTimeValue("topic", "streamsx/metrics/ingest");
 
 	graph
 		/**
@@ -48,6 +49,7 @@ public composite MetricsIngestService
 		{
 			param
 				applicationConfigurationName : $applicationConfigurationName ;
+				emitMetricTuple : periodic ;
 		}
 
 		/**
@@ -64,6 +66,6 @@ public composite MetricsIngestService
 		() as Publish_0 = Publish(TupleToJSON_0)
 		{
 			param
-				topic : "streamsx/metrics/ingest" ;
+				topic : $topic ;
 		}
 }

--- a/com.ibm.streamsx.metrics/com.ibm.streamsx.metrics.service/MetricsIngestService.spl
+++ b/com.ibm.streamsx.metrics/com.ibm.streamsx.metrics.service/MetricsIngestService.spl
@@ -6,43 +6,44 @@
 //
 
 /**
- * A metrics ingest service for the 
- * [com.ibm.streamsx.metrics::MetricsSource] operator.
- * Converts tuples to JSON and publishes it to 'streamsx/metrics/ingest' topic.
+ * A service which publishes the [com.ibm.streamsx.metrics::MetricsSource] 
+ * operator's tuples in JSON format to the 'streamsx/metrics/ingest' topic.
+ * 
+ * Output JSON Schema:
+ * {
+ *   "domainId" : string,
+ *   "instanceId" : string,
+ *   "jobId" : string,
+ *   "jobName" : string,
+ *   "resource" : string,
+ *   "peId" : long,
+ *   "operatorName" : string,
+ *   "channel" : int,
+ *   "portIndex" : int,
+ *   "connectionId" : string,
+ *   "metricType" : string,
+ *   "metricKind" : string,
+ *   "metricName" : string,
+ *   "metricValue" : long,
+ *   "lastTimeRetrieved" : long
+ * }
  */
  
 namespace com.ibm.streamsx.metrics.service;
 
-use com.ibm.streamsx.metrics::MetricsSource ;
+use com.ibm.streamsx.metrics::* ;
 use com.ibm.streamsx.json::TupleToJSON ;
 
 public composite MetricsIngestService
 {			
 	param
-		expression<rstring> $applicationConfigurationName;
-		
-	type
-		/**
-		 * The output schema of the [com.ibm.streamsx.metrics::MetricsSource] operator 
-		 * which is outputted to the [com.ibm.streamsx.json::TupleToJSON] operator.
-		 */
-		MetricType = tuple<
-				rstring metricName,
-				int64 metricValue,
-				rstring domainId,
-				rstring instanceId,
-				int64 jobId,
-				rstring jobName,
-				rstring resource,
-				int64 peId,
-				int64 lastTimeRetrieved
-			>;
+		expression<rstring> $applicationConfigurationName ;
 
 	graph
 		/**
 		 * The MetricsSource generates a tuple for each retrieved metric.
 		 */
-		stream<MetricType> MetricsSource_0 = MetricsSource()
+		stream<Notification> MetricsSource_0 = MetricsSource()
 		{
 			param
 				applicationConfigurationName : $applicationConfigurationName ;

--- a/com.ibm.streamsx.metrics/com.ibm.streamsx.metrics.service/MetricsIngestService.spl
+++ b/com.ibm.streamsx.metrics/com.ibm.streamsx.metrics.service/MetricsIngestService.spl
@@ -1,0 +1,67 @@
+//
+// ****************************************************************************
+// * Copyright (C) 2017, International Business Machines Corporation          *
+// * All rights reserved.                                                     *
+// ****************************************************************************
+//
+
+/**
+ * A metrics ingest service for the 
+ * [com.ibm.streamsx.metrics::MetricsSource] operator.
+ * Converts tuples to JSON and publishes it to 'ingest-metrics' topic.
+ */
+ 
+namespace com.ibm.streamsx.metrics.service;
+
+use com.ibm.streamsx.metrics::MetricsSource ;
+use com.ibm.streamsx.json::TupleToJSON ;
+
+public composite MetricsIngestService
+{			
+	param
+		expression<rstring> $applicationConfigurationName;
+		
+	type
+		/**
+		 * The output schema of the [com.ibm.streamsx.metrics::MetricsSource] operator 
+		 * which is outputted to the [com.ibm.streamsx.json::TupleToJSON] operator.
+		 */
+		MetricType = tuple<
+				rstring metricName,
+				int64 metricValue,
+				rstring domainId,
+				rstring instanceId,
+				int64 jobId,
+				rstring jobName,
+				rstring resource,
+				int64 peId,
+				int64 lastTimeRetrieved
+			>;
+
+	graph
+		/**
+		 * The MetricsSource generates a tuple for each retrieved metric.
+		 */
+		stream<MetricType> MetricsSource_0 = MetricsSource()
+		{
+			param
+				applicationConfigurationName: $applicationConfigurationName;
+		}
+
+		/**
+		 * The TupleToJSON converts the MetricType tuples into JSON format.
+		 */
+		stream<rstring jsonString> TupleToJSON_0 = TupleToJSON(MetricsSource_0)
+		{
+		
+		}
+		
+		/**
+		 * The Export publishes the MetricType JSON string to the 'ingest-metrics' topic.
+		 */
+		() as Export_0 = Export(TupleToJSON_0)
+		{
+			param
+				properties: { topic = "ingest-metrics" };
+		}
+}

--- a/com.ibm.streamsx.metrics/com.ibm.streamsx.metrics.service/MetricsIngestService.spl
+++ b/com.ibm.streamsx.metrics/com.ibm.streamsx.metrics.service/MetricsIngestService.spl
@@ -7,7 +7,7 @@
 
 /**
  * A service which publishes the [com.ibm.streamsx.metrics::MetricsSource] 
- * operator's tuples in JSON format to the 'streamsx/metrics/ingest' topic.
+ * operator's tuples in JSON format to the a specified topic.
  * 
  * Output JSON Schema:
  * {
@@ -39,7 +39,7 @@ public composite MetricsIngestService
 {			
 	param
 		expression<rstring> $applicationConfigurationName : getSubmissionTimeValue("applicationConfigurationName", "metricsConfig");
-		expression<rstring> $topic : getSubmissionTimeValue("topic", "streamsx/metrics/ingest");
+		expression<rstring> $topic : getSubmissionTimeValue("topic", "streamsx/metrics/values");
 
 	graph
 		/**

--- a/com.ibm.streamsx.metrics/com.ibm.streamsx.metrics.service/MetricsIngestService.spl
+++ b/com.ibm.streamsx.metrics/com.ibm.streamsx.metrics.service/MetricsIngestService.spl
@@ -32,7 +32,7 @@
 namespace com.ibm.streamsx.metrics.service;
 
 use com.ibm.streamsx.metrics::* ;
-use com.ibm.streamsx.json::TupleToJSON ;
+use com.ibm.streamsx.json::* ;
 use com.ibm.streamsx.topology.topic::Publish ;
 
 public composite MetricsIngestService
@@ -54,7 +54,7 @@ public composite MetricsIngestService
 		/**
 		 * The TupleToJSON converts the Metrics tuples into JSON format.
 		 */
-		stream<rstring jsonString> JsonMetrics = TupleToJSON(Metrics)
+		stream<Json> JsonMetrics = TupleToJSON(Metrics)
 		{
 		
 		}

--- a/com.ibm.streamsx.metrics/com.ibm.streamsx.metrics.service/MetricsIngestService.spl
+++ b/com.ibm.streamsx.metrics/com.ibm.streamsx.metrics.service/MetricsIngestService.spl
@@ -33,6 +33,7 @@ namespace com.ibm.streamsx.metrics.service;
 
 use com.ibm.streamsx.metrics::* ;
 use com.ibm.streamsx.json::TupleToJSON ;
+use com.ibm.streamsx.topology.topic::Publish ;
 
 public composite MetricsIngestService
 {			
@@ -58,11 +59,11 @@ public composite MetricsIngestService
 		}
 		
 		/**
-		 * The Export publishes the MetricType JSON string to the 'streamsx/metrics/ingest' topic.
+		 * The Publish publishes the metrics JSON string to the 'streamsx/metrics/ingest' topic.
 		 */
-		() as Export_0 = Export(TupleToJSON_0)
+		() as Publish_0 = Publish(TupleToJSON_0)
 		{
 			param
-				properties : { topic = "streamsx/metrics/ingest" } ;
+				topic : "streamsx/metrics/ingest" ;
 		}
 }


### PR DESCRIPTION
An SPL composite operator that publishes the MetricsSource's output to the "ingest-metrics" topic for other services to subscribe to.